### PR TITLE
Fix bug with notify-send

### DIFF
--- a/i3-battery-popup
+++ b/i3-battery-popup
@@ -156,7 +156,7 @@ show_notify(){
         fi
     fi
     [[ -n $NOTIFY_ICON ]] && NOTIFY_OPT="-i ${NOTIFY_ICON}"
-    notify-send -u critical "${NOTIFY_OPT}" "${1}"
+    notify-send -u critical "${1}" ${NOTIFY_OPT}
 }
 
 play_sound(){


### PR DESCRIPTION
Currently notify-send is not working, giving an error "No summary specified". After debugging I noticed that the command line put the icon option in double-quotes before the message, so if the icon is not specified the first argument will be blank, for instance:

```
notify-send -u critical "" "Warning: Battery is getting low"
```

I switched argument positions, since the message is the main argument, and always present. Also took off the double-quotes from the icon argument which would not work.